### PR TITLE
Continue on error

### DIFF
--- a/enocean/communicators/serialcommunicator.py
+++ b/enocean/communicators/serialcommunicator.py
@@ -36,6 +36,7 @@ class SerialCommunicator(Communicator):
             except serial.SerialException:
                 self.logger.error('Serial port exception! (device disconnected or multiple access on port?)')
                 self.stop()
+                continue
             self.parse()
             time.sleep(0)
 


### PR DESCRIPTION
If the port is busy do not parse anything.
Without this I am able to start multiple communicators per port and send a command to it in this short timeframe.